### PR TITLE
Added index.js and modified package.json for node.js compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/date.js');
+module.exports = require('./lib/date-de-DE.js');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/date.js');

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     , "url" : "http://github.com/chrisdew/datejs"
     }
   ]
-, "main" : "./lib/date.js"
+, "main" : "./index.js"
 , "engines" : { "node" : ">=0.2.6" }
 , "dependencies" : { "vows" : ">=0.5.2"
                    }


### PR DESCRIPTION
Added index.js and modified package.json for node.js compatibility -- now just require('datejs'); on a single line, without anything else.

Tested with v0.4.11 and v0.4.12
